### PR TITLE
Add interactive banking ledger with interest calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,4 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+state.json

--- a/LOGS.md
+++ b/LOGS.md
@@ -1,5 +1,9 @@
 # LOGS
 
+## Implementation [Codex] 2025-08-17 17:14
+- Implemented ledger, CLI, docs and tests.
+
+
 session logs are timestamped to Singapore timezone in reverse chronological order, with latest entries at the top, and earlier entries at the bottom.
 
 ## UI program [Data Engineer] Codex prompt 2025-08-17 17:12

--- a/bank/drive.py
+++ b/bank/drive.py
@@ -1,0 +1,37 @@
+from . import state
+
+ledger = state.load()
+
+
+def state_refresh():
+    global ledger
+    ledger = state.load()
+
+
+def transaction_add(date: str, account: str, t_type: str, amount: float):
+    try:
+        txn = ledger.add_transaction(date, account, t_type, float(amount))
+    except Exception as e:
+        return {'success': -1, 'error': str(e)}
+    else:
+        state.save(ledger)
+        return {'success': 1, 'txn_id': txn.txn_id}
+
+
+def rule_add(date: str, rule_id: str, rate: float):
+    try:
+        ledger.add_rule(date, rule_id, float(rate))
+    except Exception as e:
+        return {'success': -1, 'error': str(e)}
+    else:
+        state.save(ledger)
+        return {'success': 1}
+
+
+def statement(account: str, year_month: str):
+    try:
+        result = ledger.statement(account, year_month)
+    except Exception as e:
+        return {'success': -1, 'error': str(e)}
+    else:
+        return {'success': 1, **result}

--- a/bank/ledger.py
+++ b/bank/ledger.py
@@ -1,0 +1,200 @@
+import datetime as dt
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+
+@dataclass
+class Transaction:
+    date: dt.date
+    txn_id: str
+    type: str  # 'D', 'W'
+    amount: float
+
+
+@dataclass
+class InterestRule:
+    date: dt.date
+    rule_id: str
+    rate: float  # percentage
+
+
+@dataclass
+class Account:
+    name: str
+    transactions: List[Transaction] = field(default_factory=list)
+
+    def add_transaction(self, txn: Transaction) -> None:
+        self.transactions.append(txn)
+        self.transactions.sort(key=lambda t: (t.date, t.txn_id))
+
+    def balance_before(self, date: dt.date) -> float:
+        bal = 0.0
+        for t in sorted(self.transactions, key=lambda t: (t.date, t.txn_id)):
+            if t.date >= date:
+                break
+            if t.type.upper() == 'D':
+                bal += t.amount
+            elif t.type.upper() == 'W':
+                bal -= t.amount
+            elif t.type.upper() == 'I':
+                bal += t.amount
+        return bal
+
+    def transactions_in_month(self, year: int, month: int) -> List[Transaction]:
+        return [
+            t for t in sorted(self.transactions, key=lambda t: (t.date, t.txn_id))
+            if t.date.year == year and t.date.month == month
+        ]
+
+
+class Ledger:
+    def __init__(self):
+        self.accounts: Dict[str, Account] = {}
+        self.rules: List[InterestRule] = []
+
+    # --- account and transaction handling ---
+    def _get_account(self, name: str) -> Account:
+        if name not in self.accounts:
+            self.accounts[name] = Account(name)
+        return self.accounts[name]
+
+    def add_transaction(self, date_str: str, account_name: str, t_type: str, amount: float) -> Transaction:
+        date = dt.datetime.strptime(date_str, '%Y%m%d').date()
+        t_type = t_type.upper()
+        if t_type not in ('D', 'W'):
+            raise ValueError('Type must be D or W')
+        if amount <= 0:
+            raise ValueError('Amount must be greater than 0')
+        acc = self._get_account(account_name)
+        # check balance for withdrawal
+        if t_type == 'W':
+            bal_before = acc.balance_before(date)
+            # also include earlier transactions same day before this one
+            for t in acc.transactions:
+                if t.date == date:
+                    if t.type.upper() == 'D':
+                        bal_before += t.amount
+                    elif t.type.upper() in ('W', 'I'):
+                        bal_before -= t.amount
+            if bal_before - amount < 0:
+                raise ValueError('Balance cannot go below 0')
+        # generate txn id
+        count = len([t for t in acc.transactions if t.date == date]) + 1
+        txn_id = f"{date_str}-{count:02d}"
+        txn = Transaction(date=date, txn_id=txn_id, type=t_type, amount=round(amount, 2))
+        acc.add_transaction(txn)
+        return txn
+
+    # --- interest rules ---
+    def add_rule(self, date_str: str, rule_id: str, rate: float) -> InterestRule:
+        if not (0 < rate < 100):
+            raise ValueError('Rate must be between 0 and 100')
+        date = dt.datetime.strptime(date_str, '%Y%m%d').date()
+        # remove existing rule same date
+        self.rules = [r for r in self.rules if r.date != date]
+        rule = InterestRule(date=date, rule_id=rule_id, rate=rate)
+        self.rules.append(rule)
+        self.rules.sort(key=lambda r: r.date)
+        return rule
+
+    def _rate_for_date(self, date: dt.date) -> float:
+        applicable = [r for r in self.rules if r.date <= date]
+        if not applicable:
+            return 0.0
+        return applicable[-1].rate
+
+    # --- statement and interest ---
+    def statement(self, account_name: str, year_month: str) -> Dict[str, str]:
+        year = int(year_month[:4])
+        month = int(year_month[4:])
+        acc = self.accounts.get(account_name)
+        if not acc:
+            raise ValueError('Account not found')
+        transactions = acc.transactions_in_month(year, month)
+        start_date = dt.date(year, month, 1)
+        if month == 12:
+            end_date = dt.date(year + 1, 1, 1) - dt.timedelta(days=1)
+        else:
+            end_date = dt.date(year, month + 1, 1) - dt.timedelta(days=1)
+        balance = acc.balance_before(start_date)
+        lines = [f"Account: {account_name}", "| Date     | Txn Id      | Type | Amount | Balance |"]
+        # map date to transactions
+        txns_by_day: Dict[dt.date, List[Transaction]] = {}
+        for t in transactions:
+            txns_by_day.setdefault(t.date, []).append(t)
+        interest_total = 0.0
+        day = start_date
+        while day <= end_date:
+            day_txns = txns_by_day.get(day, [])
+            for t in day_txns:
+                if t.type == 'D':
+                    balance += t.amount
+                elif t.type == 'W':
+                    balance -= t.amount
+                lines.append(
+                    f"| {t.date.strftime('%Y%m%d')} | {t.txn_id:<11} | {t.type}    | {t.amount:7.2f} | {balance:8.2f} |"
+                )
+            rate = self._rate_for_date(day)
+            interest_total += balance * rate
+            day += dt.timedelta(days=1)
+        interest = round(interest_total / 100 / 365, 2)
+        balance += interest
+        interest_date = end_date.strftime('%Y%m%d')
+        lines.append(
+            f"| {interest_date} |             | I    | {interest:7.2f} | {balance:8.2f} |"
+        )
+        statement_text = '\n'.join(lines)
+        return {
+            'statement': statement_text,
+            'interest': interest
+        }
+
+    def to_dict(self) -> Dict:
+        data = {
+            'accounts': {
+                name: [
+                    {
+                        'date': t.date.strftime('%Y%m%d'),
+                        'txn_id': t.txn_id,
+                        'type': t.type,
+                        'amount': t.amount,
+                    }
+                    for t in acc.transactions
+                ]
+                for name, acc in self.accounts.items()
+            },
+            'rules': [
+                {
+                    'date': r.date.strftime('%Y%m%d'),
+                    'rule_id': r.rule_id,
+                    'rate': r.rate,
+                }
+                for r in self.rules
+            ],
+        }
+        return data
+
+    @classmethod
+    def from_dict(cls, data: Dict) -> 'Ledger':
+        ledger = cls()
+        for name, txns in data.get('accounts', {}).items():
+            acc = ledger._get_account(name)
+            for t in txns:
+                acc.add_transaction(
+                    Transaction(
+                        date=dt.datetime.strptime(t['date'], '%Y%m%d').date(),
+                        txn_id=t['txn_id'],
+                        type=t['type'],
+                        amount=t['amount'],
+                    )
+                )
+        for r in data.get('rules', []):
+            ledger.rules.append(
+                InterestRule(
+                    date=dt.datetime.strptime(r['date'], '%Y%m%d').date(),
+                    rule_id=r['rule_id'],
+                    rate=r['rate'],
+                )
+            )
+        ledger.rules.sort(key=lambda r: r.date)
+        return ledger

--- a/bank/state.py
+++ b/bank/state.py
@@ -1,0 +1,16 @@
+import json
+from pathlib import Path
+from .ledger import Ledger
+
+STATE_FILE = Path(__file__).resolve().parent.parent / 'state.json'
+
+
+def load() -> Ledger:
+    if STATE_FILE.exists():
+        data = json.loads(STATE_FILE.read_text())
+        return Ledger.from_dict(data)
+    return Ledger()
+
+
+def save(ledger: Ledger) -> None:
+    STATE_FILE.write_text(json.dumps(ledger.to_dict(), indent=2))

--- a/bank/ui.py
+++ b/bank/ui.py
@@ -1,0 +1,83 @@
+"""Simple banking CLI using ledger module."""
+
+from . import drive
+
+
+class BankApp:
+    def __init__(self, input_fn=input, output_fn=print):
+        self.input_fn = input_fn
+        self.output_fn = output_fn
+        drive.state_refresh()
+
+    def run(self):
+        self.output_fn("Welcome to AwesomeGIC Bank! What would you like to do?")
+        while True:
+            self.output_fn("[T] Input transactions\n[I] Define interest rules\n[P] Print statement\n[Q] Quit")
+            choice = self.input_fn("> ").strip().lower()
+            if choice == 't':
+                self._input_transactions()
+            elif choice == 'i':
+                self._define_interest_rules()
+            elif choice == 'p':
+                self._print_statement()
+            elif choice == 'q':
+                self.output_fn("Thank you for banking with AwesomeGIC Bank.\nHave a nice day!")
+                break
+            else:
+                self.output_fn("Invalid option. Please try again.")
+
+    def _input_transactions(self):
+        self.output_fn("Please enter transaction details in <Date> <Account> <Type> <Amount> format\n(or enter blank to go back to main menu):")
+        while True:
+            line = self.input_fn("> ").strip()
+            if not line:
+                return
+            parts = line.split()
+            if len(parts) != 4:
+                self.output_fn("Invalid input. Expected 4 fields.")
+                continue
+            date, account, ttype, amount = parts
+            response = drive.transaction_add(date, account, ttype, amount)
+            if response['success'] == 1:
+                self.output_fn(f"Transaction recorded with id {response['txn_id']}")
+            else:
+                self.output_fn(response['error'])
+
+    def _define_interest_rules(self):
+        self.output_fn("Please enter interest rules details in <Date> <RuleId> <Rate in %> format\n(or enter blank to go back to main menu):")
+        while True:
+            line = self.input_fn("> ").strip()
+            if not line:
+                return
+            parts = line.split()
+            if len(parts) != 3:
+                self.output_fn("Invalid input. Expected 3 fields.")
+                continue
+            date, rule_id, rate = parts
+            response = drive.rule_add(date, rule_id, rate)
+            if response['success'] == 1:
+                self.output_fn("Rule recorded")
+            else:
+                self.output_fn(response['error'])
+
+    def _print_statement(self):
+        self.output_fn("Please enter account and month to generate the statement <Account> <Year><Month>\n(or enter blank to go back to main menu):")
+        while True:
+            line = self.input_fn("> ").strip()
+            if not line:
+                return
+            parts = line.split()
+            if len(parts) != 2:
+                self.output_fn("Invalid input. Expected 2 fields.")
+                continue
+            account, ym = parts
+            response = drive.statement(account, ym)
+            if response['success'] == 1:
+                self.output_fn(response['statement'])
+                break
+            else:
+                self.output_fn(response['error'])
+
+
+if __name__ == '__main__':
+    BankApp().run()

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -1,0 +1,34 @@
+# Developer Guide
+
+## Architecture
+
+The application is a small command line program implemented using an object-oriented design.
+
+- `bank/ledger.py` – domain models and the `Ledger` class that manages accounts, transactions and interest rules.
+- `bank/state.py` – persistence helper that saves and loads ledger data from `state.json`.
+- `bank/drive.py` – thin wrapper exposing functions used by the UI. All functions return dictionaries with a `success` flag and optional data or error message.
+- `bank/ui.py` – interactive command line interface.
+
+## Data model
+
+- **Account** holds a list of `Transaction` objects.
+- **Transaction** records `date`, `txn_id`, `type` (`D`, `W`, `I`) and `amount`.
+- **InterestRule** defines the interest rate that applies from a given date forward.
+
+State is persisted as JSON in `state.json` at the project root. `Ledger.to_dict()` and `Ledger.from_dict()` serialize and restore the state.
+
+## Coding conventions
+
+- Only the Python standard library is used.
+- Functions in `drive.py` return dictionaries of the form `{'success': 1, ...}` or `{'success': -1, 'error': 'message'}`.
+- Tests in `tests.py` use `unittest`.
+
+## Running tests
+
+```bash
+pytest tests.py
+```
+
+## Logging
+
+The project is small and relies on return values for error reporting. Additional logging can be added by instrumenting the `drive` and `ledger` modules.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,0 +1,58 @@
+# User Guide
+
+## Installation
+
+This project requires Python 3.8+ and has no external dependencies.
+
+1. Clone the repository and change into the project directory.
+2. (Optional) Create a virtual environment.
+3. Run the interactive program:
+
+```bash
+python -m bank.ui
+```
+
+## Usage
+
+When launched the program displays a menu:
+
+```
+Welcome to AwesomeGIC Bank! What would you like to do?
+[T] Input transactions
+[I] Define interest rules
+[P] Print statement
+[Q] Quit
+>
+```
+
+### Input transactions
+Enter a line with `Date Account Type Amount`.
+Example:
+```
+20230626 AC001 W 100.00
+```
+Type `Enter` on an empty line to return to the main menu.
+
+### Define interest rules
+Enter `Date RuleId Rate`.
+Example:
+```
+20230615 RULE03 2.20
+```
+The latest rule on a given date replaces earlier rules.
+
+### Print statement
+Enter `Account YearMonth` to generate a monthly statement including interest.
+Example:
+```
+AC001 202306
+```
+
+### Quit
+Enter `Q` from the main menu.
+
+## Common errors
+
+- **Invalid date format** – Dates must be in `YYYYMMDD` or `YYYYMM` format.
+- **Insufficient balance** – Withdrawals cannot result in a negative balance.
+- **Invalid interest rate** – Rates must be between 0 and 100.

--- a/tests.py
+++ b/tests.py
@@ -1,1 +1,45 @@
-#!/usr/bin/env python3
+import os
+import unittest
+from bank import drive, state
+
+
+class BankTests(unittest.TestCase):
+    def setUp(self):
+        # ensure fresh state
+        if state.STATE_FILE.exists():
+            state.STATE_FILE.unlink()
+        drive.state_refresh()
+
+    def test_deposit_and_withdraw(self):
+        r1 = drive.transaction_add('20230601', 'AC001', 'D', 100)
+        self.assertEqual(1, r1['success'])
+        r2 = drive.transaction_add('20230602', 'AC001', 'W', 50)
+        self.assertEqual(1, r2['success'])
+        stmt = drive.statement('AC001', '202306')
+        self.assertEqual(1, stmt['success'])
+        self.assertIn('20230601-01', stmt['statement'])
+        self.assertIn('20230602-01', stmt['statement'])
+
+    def test_withdrawal_insufficient_balance(self):
+        drive.transaction_add('20230601', 'AC002', 'D', 50)
+        resp = drive.transaction_add('20230602', 'AC002', 'W', 60)
+        self.assertEqual(-1, resp['success'])
+
+    def test_interest_calculation(self):
+        # setup transactions
+        drive.transaction_add('20230505', 'AC001', 'D', 100)
+        drive.transaction_add('20230601', 'AC001', 'D', 150)
+        drive.transaction_add('20230626', 'AC001', 'W', 20)
+        drive.transaction_add('20230626', 'AC001', 'W', 100)
+        # rules
+        drive.rule_add('20230101', 'RULE01', 1.95)
+        drive.rule_add('20230520', 'RULE02', 1.90)
+        drive.rule_add('20230615', 'RULE03', 2.20)
+        stmt = drive.statement('AC001', '202306')
+        self.assertEqual(1, stmt['success'])
+        self.assertAlmostEqual(0.39, stmt['interest'], places=2)
+        self.assertIn('| 20230630 |             | I    |', stmt['statement'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement ledger domain and persistence
- add CLI for transactions, interest rules and statement printing
- document user and developer guides
- add unit tests for transactions and interest computation

## Testing
- `pytest tests.py`


------
https://chatgpt.com/codex/tasks/task_e_68a19cb67ed48323961f92c3861b9139